### PR TITLE
Bugfix ovg2

### DIFF
--- a/Mailer/TwigSwiftMailer.php
+++ b/Mailer/TwigSwiftMailer.php
@@ -47,7 +47,7 @@ class TwigSwiftMailer implements MailerInterface
      * @param \Twig_Environment     $twig
      * @param array                 $parameters
      */
-    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig_Environment $twig, array $parameters)
+    public function __construct(\Swift_Mailer $mailer, UrlGeneratorInterface $router, \Twig\Environment $twig, array $parameters)
     {
         $this->mailer = $mailer;
         $this->router = $router;

--- a/Model/UserInterface.php
+++ b/Model/UserInterface.php
@@ -277,18 +277,18 @@ interface FosUserInterface extends \Serializable
     public function isEnabled();
 }
 
-// This is required to support apps that explicitly check if a user is an instance of AdvancedUserInterface
-if (interface_exists('\Symfony\Component\Security\Core\User\AdvancedUserInterface')) {
-    /**
-     * @author Thibault Duplessis <thibault.duplessis@gmail.com>
-     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
-     *
-     * @deprecated since Symfony 4.1. Remove in Nov 2023 (End of support for security fixes SF 4.4)
-     */
-    interface UserInterface extends FosUserInterface, \Symfony\Component\Security\Core\User\AdvancedUserInterface
-    {
-    }
-} else {
+//// This is required to support apps that explicitly check if a user is an instance of AdvancedUserInterface
+//if (interface_exists('\Symfony\Component\Security\Core\User\AdvancedUserInterface')) {
+//    /**
+//     * @author Thibault Duplessis <thibault.duplessis@gmail.com>
+//     * @author Johannes M. Schmitt <schmittjoh@gmail.com>
+//     *
+//     * @deprecated since Symfony 4.1. Remove in Nov 2023 (End of support for security fixes SF 4.4)
+//     */
+//    interface UserInterface extends FosUserInterface, \Symfony\Component\Security\Core\User\AdvancedUserInterface
+//    {
+//    }
+//} else {
     /**
      * @author Thibault Duplessis <thibault.duplessis@gmail.com>
      * @author Johannes M. Schmitt <schmittjoh@gmail.com>
@@ -297,4 +297,4 @@ if (interface_exists('\Symfony\Component\Security\Core\User\AdvancedUserInterfac
     interface UserInterface extends FosUserInterface, BaseUserInterface, EquatableInterface
     {
     }
-}
+//}

--- a/Tests/EventListener/FlashListenerTest.php
+++ b/Tests/EventListener/FlashListenerTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Session\Flash\FlashBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Contracts\EventDispatcher\Event;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Contracts\Translation\TranslatorInterface;
 
 class FlashListenerTest extends TestCase
 {

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
     "require": {
         "php": "^7.2.5",
         "paragonie/random_compat": "^1 || ^2 || ^9",
-        "symfony/form": "^4.4 || ^5.0",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
-        "symfony/security-bundle": "^4.4 || ^5.0",
-        "symfony/templating": "^4.4 || ^5.0",
-        "symfony/translation": "^4.4 || ^5.0",
+        "symfony/form": "^4.4",
+        "symfony/framework-bundle": "^4.4",
+        "symfony/security-bundle": "^4.4",
+        "symfony/templating": "^4.4",
+        "symfony/translation": "^4.4",
         "symfony/translation-contracts": "^2.0",
-        "symfony/twig-bundle": "^4.4 || ^5.0",
-        "symfony/validator": "^4.4 || ^5.0",
+        "symfony/twig-bundle": "^4.4",
+        "symfony/validator": "^4.4",
         "twig/twig": "^1.28 || ^2.0"
     },
     "conflict": {
@@ -42,9 +42,9 @@
         "friendsofphp/php-cs-fixer": "^2.2",
         "phpunit/phpunit": "^4.8.35 || ^5.7.11 || ^6.5 || ^8",
         "swiftmailer/swiftmailer": "^4.3 || ^5.0 || ^6.0",
-        "symfony/console": "^4.4 || ^5.0",
+        "symfony/console": "^4.4",
         "symfony/phpunit-bridge": "^3.4 || ^4.2 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/yaml": "^4.4"
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
Thanks again for this fork of FOSUserBundle.

In addition to some minor fixes, this pr eliminates the bundle's use of AdvancedUserInterface under symfony 4.4, and removes that deprecation for those using symfony 4.4.

Note that as described in index.rst, "user_checker: fos_user.user_checker" has to be added to the firewall config in security.yaml to enable checking for disabled (i.e., created but not confirmed) accounts.